### PR TITLE
feat: Add RLM + Graph analysis mode with knowledge graph extraction

### DIFF
--- a/src/app/__tests__/page.test.tsx
+++ b/src/app/__tests__/page.test.tsx
@@ -160,7 +160,10 @@ describe("Home Page", () => {
       await waitFor(() => {
         expect(screen.getByRole("tab", { name: /base/i })).toBeInTheDocument();
         expect(screen.getByRole("tab", { name: /retrieval/i })).toBeInTheDocument();
-        expect(screen.getByRole("tab", { name: /rlm/i })).toBeInTheDocument();
+        // RLM tab has "RLM" and "Recursive" in its name
+        expect(screen.getByRole("tab", { name: /rlm.*recursive/i })).toBeInTheDocument();
+        // RLM + Graph tab has "RLM + Graph" and "Knowledge Graph" in its name
+        expect(screen.getByRole("tab", { name: /rlm \+ graph/i })).toBeInTheDocument();
       });
     });
 

--- a/src/lib/__tests__/graph.test.ts
+++ b/src/lib/__tests__/graph.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect } from "vitest";
+import { mergeEntities, buildGraph, summarizeGraph } from "@/lib/graph";
+import type { EntityExtraction } from "@/lib/types";
+
+describe("graph", () => {
+  describe("mergeEntities", () => {
+    it("should merge identical entities from different chunks", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+            ],
+            relationships: [],
+          },
+        },
+        {
+          chunkId: "chunk-2",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.8 },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+
+      const nodes = mergeEntities(extractions);
+      expect(nodes).toHaveLength(1);
+      expect(nodes[0].name).toBe("Acme Corp");
+      expect(nodes[0].sourceChunks).toEqual(["chunk-1", "chunk-2"]);
+      expect(nodes[0].confidence).toBe(0.9); // Takes max confidence
+    });
+
+    it("should merge similar entities with high similarity", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corporation", confidence: 0.9 },
+            ],
+            relationships: [],
+          },
+        },
+        {
+          chunkId: "chunk-2",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.8 },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+
+      const nodes = mergeEntities(extractions);
+      // Should merge because "Acme Corp" is contained in "Acme Corporation"
+      expect(nodes).toHaveLength(1);
+    });
+
+    it("should keep different entities separate", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+              { type: "party" as const, name: "Beta LLC", confidence: 0.8 },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+
+      const nodes = mergeEntities(extractions);
+      expect(nodes).toHaveLength(2);
+    });
+
+    it("should not merge entities of different types even with same name", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Payment", confidence: 0.9 },
+              { type: "obligation" as const, name: "Payment", confidence: 0.8 },
+            ],
+            relationships: [],
+          },
+        },
+      ];
+
+      const nodes = mergeEntities(extractions);
+      expect(nodes).toHaveLength(2);
+    });
+
+    it("should handle empty extractions", () => {
+      const nodes = mergeEntities([]);
+      expect(nodes).toHaveLength(0);
+    });
+  });
+
+  describe("buildGraph", () => {
+    it("should build a complete graph with nodes and edges", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+              { type: "obligation" as const, name: "Payment of $50,000", confidence: 0.85 },
+            ],
+            relationships: [
+              {
+                type: "has_obligation" as const,
+                sourceName: "Acme Corp",
+                targetName: "Payment of $50,000",
+                confidence: 0.8,
+              },
+            ],
+          },
+        },
+      ];
+
+      const graph = buildGraph(extractions, 1, "gpt-4");
+
+      expect(graph.nodes).toHaveLength(2);
+      expect(graph.edges).toHaveLength(1);
+      expect(graph.metadata.documentCount).toBe(1);
+      expect(graph.metadata.chunkCount).toBe(1);
+      expect(graph.metadata.extractionModel).toBe("gpt-4");
+
+      // Check edge connects correct nodes
+      const edge = graph.edges[0];
+      const sourceNode = graph.nodes.find((n) => n.id === edge.source);
+      const targetNode = graph.nodes.find((n) => n.id === edge.target);
+      expect(sourceNode?.name).toBe("Acme Corp");
+      expect(targetNode?.name).toBe("Payment of $50,000");
+    });
+
+    it("should not create edges for non-existent nodes", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+            ],
+            relationships: [
+              {
+                type: "has_obligation" as const,
+                sourceName: "Acme Corp",
+                targetName: "NonExistent Entity",
+                confidence: 0.8,
+              },
+            ],
+          },
+        },
+      ];
+
+      const graph = buildGraph(extractions, 1, "gpt-4");
+      expect(graph.edges).toHaveLength(0);
+    });
+
+    it("should not create duplicate edges", () => {
+      const extractions = [
+        {
+          chunkId: "chunk-1",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+              { type: "obligation" as const, name: "Payment", confidence: 0.85 },
+            ],
+            relationships: [
+              {
+                type: "has_obligation" as const,
+                sourceName: "Acme Corp",
+                targetName: "Payment",
+                confidence: 0.8,
+              },
+            ],
+          },
+        },
+        {
+          chunkId: "chunk-2",
+          extraction: {
+            entities: [
+              { type: "party" as const, name: "Acme Corp", confidence: 0.9 },
+              { type: "obligation" as const, name: "Payment", confidence: 0.85 },
+            ],
+            relationships: [
+              {
+                type: "has_obligation" as const,
+                sourceName: "Acme Corp",
+                targetName: "Payment",
+                confidence: 0.9,
+              },
+            ],
+          },
+        },
+      ];
+
+      const graph = buildGraph(extractions, 1, "gpt-4");
+      expect(graph.edges).toHaveLength(1);
+    });
+  });
+
+  describe("summarizeGraph", () => {
+    it("should summarize an empty graph", () => {
+      const graph = {
+        nodes: [],
+        edges: [],
+        metadata: { documentCount: 0, chunkCount: 0, extractionModel: "gpt-4" },
+      };
+
+      const summary = summarizeGraph(graph);
+      expect(summary).toContain("No entities");
+    });
+
+    it("should summarize a graph with nodes and edges", () => {
+      const graph = {
+        nodes: [
+          { id: "n1", type: "party" as const, name: "Acme Corp", properties: {}, sourceChunks: ["chunk-1"], confidence: 0.9 },
+          { id: "n2", type: "obligation" as const, name: "Payment", properties: {}, sourceChunks: ["chunk-1"], confidence: 0.85 },
+        ],
+        edges: [
+          { id: "e1", type: "has_obligation" as const, source: "n1", target: "n2", properties: {}, sourceChunk: "chunk-1", confidence: 0.8 },
+        ],
+        metadata: { documentCount: 1, chunkCount: 1, extractionModel: "gpt-4" },
+      };
+
+      const summary = summarizeGraph(graph);
+      expect(summary).toContain("Entities: 2");
+      expect(summary).toContain("Relationships: 1");
+      expect(summary).toContain("party");
+      expect(summary).toContain("Acme Corp");
+      expect(summary).toContain("Payment");
+    });
+
+    it("should group entities by type", () => {
+      const graph = {
+        nodes: [
+          { id: "n1", type: "party" as const, name: "Acme Corp", properties: {}, sourceChunks: [], confidence: 0.9 },
+          { id: "n2", type: "party" as const, name: "Beta LLC", properties: {}, sourceChunks: [], confidence: 0.9 },
+          { id: "n3", type: "date" as const, name: "2024-01-01", properties: {}, sourceChunks: [], confidence: 0.9 },
+        ],
+        edges: [],
+        metadata: { documentCount: 1, chunkCount: 1, extractionModel: "gpt-4" },
+      };
+
+      const summary = summarizeGraph(graph);
+      expect(summary).toContain("party: Acme Corp, Beta LLC");
+      expect(summary).toContain("date: 2024-01-01");
+    });
+  });
+});

--- a/src/lib/__tests__/prompts.test.ts
+++ b/src/lib/__tests__/prompts.test.ts
@@ -4,6 +4,9 @@ import {
   SUB_PROMPT,
   RETRIEVAL_PROMPT,
   REWRITE_PROMPT,
+  ENTITY_EXTRACTION_PROMPT,
+  GRAPH_SUB_PROMPT,
+  GRAPH_ROOT_PROMPT,
 } from "@/lib/prompts";
 
 describe("prompts", () => {
@@ -54,17 +57,68 @@ describe("prompts", () => {
     });
   });
 
+  describe("ENTITY_EXTRACTION_PROMPT", () => {
+    it("should list entity types", () => {
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("party");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("date");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("amount");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("clause");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("obligation");
+    });
+
+    it("should list relationship types", () => {
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("has_obligation");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("has_right");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("references");
+    });
+
+    it("should specify JSON output format", () => {
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("JSON");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("entities");
+      expect(ENTITY_EXTRACTION_PROMPT).toContain("relationships");
+    });
+  });
+
+  describe("GRAPH_SUB_PROMPT", () => {
+    it("should mention both findings and entities", () => {
+      expect(GRAPH_SUB_PROMPT).toContain("FINDINGS");
+      expect(GRAPH_SUB_PROMPT).toContain("ENTITIES");
+    });
+
+    it("should specify JSON output format", () => {
+      expect(GRAPH_SUB_PROMPT).toContain("JSON");
+      expect(GRAPH_SUB_PROMPT).toContain("finding");
+      expect(GRAPH_SUB_PROMPT).toContain("extraction");
+    });
+  });
+
+  describe("GRAPH_ROOT_PROMPT", () => {
+    it("should mention knowledge graph context", () => {
+      expect(GRAPH_ROOT_PROMPT).toContain("knowledge graph");
+    });
+
+    it("should include citation format instructions", () => {
+      expect(GRAPH_ROOT_PROMPT).toMatch(/\[.*chunk.*\]/i);
+    });
+  });
+
   describe("general prompt properties", () => {
     it("all prompts should be non-empty strings", () => {
       expect(typeof ROOT_PROMPT).toBe("string");
       expect(typeof SUB_PROMPT).toBe("string");
       expect(typeof RETRIEVAL_PROMPT).toBe("string");
       expect(typeof REWRITE_PROMPT).toBe("string");
+      expect(typeof ENTITY_EXTRACTION_PROMPT).toBe("string");
+      expect(typeof GRAPH_SUB_PROMPT).toBe("string");
+      expect(typeof GRAPH_ROOT_PROMPT).toBe("string");
 
       expect(ROOT_PROMPT.length).toBeGreaterThan(0);
       expect(SUB_PROMPT.length).toBeGreaterThan(0);
       expect(RETRIEVAL_PROMPT.length).toBeGreaterThan(0);
       expect(REWRITE_PROMPT.length).toBeGreaterThan(0);
+      expect(ENTITY_EXTRACTION_PROMPT.length).toBeGreaterThan(0);
+      expect(GRAPH_SUB_PROMPT.length).toBeGreaterThan(0);
+      expect(GRAPH_ROOT_PROMPT.length).toBeGreaterThan(0);
     });
 
     it("all prompts should be trimmed", () => {
@@ -72,6 +126,9 @@ describe("prompts", () => {
       expect(SUB_PROMPT).toBe(SUB_PROMPT.trim());
       expect(RETRIEVAL_PROMPT).toBe(RETRIEVAL_PROMPT.trim());
       expect(REWRITE_PROMPT).toBe(REWRITE_PROMPT.trim());
+      expect(ENTITY_EXTRACTION_PROMPT).toBe(ENTITY_EXTRACTION_PROMPT.trim());
+      expect(GRAPH_SUB_PROMPT).toBe(GRAPH_SUB_PROMPT.trim());
+      expect(GRAPH_ROOT_PROMPT).toBe(GRAPH_ROOT_PROMPT.trim());
     });
   });
 });

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -1,0 +1,248 @@
+import type {
+  EntityExtraction,
+  EntityType,
+  GraphEdge,
+  GraphNode,
+  KnowledgeGraph,
+  RelationType,
+} from "@/lib/types";
+
+type ChunkExtraction = {
+  chunkId: string;
+  extraction: EntityExtraction;
+};
+
+const normalizeEntityName = (name: string): string => {
+  return name.toLowerCase().trim().replace(/\s+/g, " ");
+};
+
+const calculateSimilarity = (a: string, b: string): number => {
+  const aNorm = normalizeEntityName(a);
+  const bNorm = normalizeEntityName(b);
+
+  if (aNorm === bNorm) return 1;
+
+  // Check if one contains the other
+  if (aNorm.includes(bNorm) || bNorm.includes(aNorm)) {
+    return 0.8;
+  }
+
+  // Simple Jaccard similarity on words
+  const aWords = new Set(aNorm.split(" "));
+  const bWords = new Set(bNorm.split(" "));
+  const intersection = new Set([...aWords].filter((w) => bWords.has(w)));
+  const union = new Set([...aWords, ...bWords]);
+
+  return intersection.size / union.size;
+};
+
+type RawEntity = {
+  type: EntityType;
+  name: string;
+  properties: Record<string, unknown>;
+  confidence: number;
+  sourceChunks: string[];
+};
+
+export const mergeEntities = (
+  extractions: ChunkExtraction[],
+  similarityThreshold = 0.7,
+): GraphNode[] => {
+  const rawEntities: RawEntity[] = [];
+
+  // Collect all entities from extractions
+  for (const { chunkId, extraction } of extractions) {
+    for (const entity of extraction.entities) {
+      rawEntities.push({
+        type: entity.type,
+        name: entity.name,
+        properties: entity.properties ?? {},
+        confidence: entity.confidence,
+        sourceChunks: [chunkId],
+      });
+    }
+  }
+
+  // Group entities by type for more efficient merging
+  const entitiesByType = new Map<EntityType, RawEntity[]>();
+  for (const entity of rawEntities) {
+    const existing = entitiesByType.get(entity.type) ?? [];
+    existing.push(entity);
+    entitiesByType.set(entity.type, existing);
+  }
+
+  // Merge similar entities within each type
+  const mergedEntities: RawEntity[] = [];
+
+  for (const [type, entities] of entitiesByType) {
+    const merged: RawEntity[] = [];
+
+    for (const entity of entities) {
+      let foundMatch = false;
+
+      for (const existing of merged) {
+        const similarity = calculateSimilarity(entity.name, existing.name);
+        if (similarity >= similarityThreshold) {
+          // Merge into existing entity
+          existing.sourceChunks = [
+            ...new Set([...existing.sourceChunks, ...entity.sourceChunks]),
+          ];
+          existing.confidence = Math.max(existing.confidence, entity.confidence);
+          // Merge properties, preferring higher confidence values
+          existing.properties = { ...existing.properties, ...entity.properties };
+          foundMatch = true;
+          break;
+        }
+      }
+
+      if (!foundMatch) {
+        merged.push({ ...entity });
+      }
+    }
+
+    mergedEntities.push(...merged);
+  }
+
+  // Convert to GraphNodes with unique IDs
+  return mergedEntities.map((entity, index) => ({
+    id: `n${index + 1}`,
+    type: entity.type,
+    name: entity.name,
+    properties: entity.properties,
+    sourceChunks: entity.sourceChunks,
+    confidence: entity.confidence,
+  }));
+};
+
+export const buildGraph = (
+  extractions: ChunkExtraction[],
+  documentCount: number,
+  extractionModel: string,
+): KnowledgeGraph => {
+  // Merge entities
+  const nodes = mergeEntities(extractions);
+
+  // Build name-to-node lookup for edge construction
+  const nodesByName = new Map<string, GraphNode>();
+  for (const node of nodes) {
+    nodesByName.set(normalizeEntityName(node.name), node);
+  }
+
+  // Find node by name with fuzzy matching
+  const findNodeByName = (name: string): GraphNode | undefined => {
+    const normalized = normalizeEntityName(name);
+
+    // Exact match first
+    if (nodesByName.has(normalized)) {
+      return nodesByName.get(normalized);
+    }
+
+    // Fuzzy match
+    for (const [nodeName, node] of nodesByName) {
+      if (calculateSimilarity(normalized, nodeName) >= 0.7) {
+        return node;
+      }
+    }
+
+    return undefined;
+  };
+
+  // Build edges from relationships
+  const edges: GraphEdge[] = [];
+  let edgeIndex = 0;
+
+  for (const { chunkId, extraction } of extractions) {
+    for (const rel of extraction.relationships) {
+      const sourceNode = findNodeByName(rel.sourceName);
+      const targetNode = findNodeByName(rel.targetName);
+
+      if (sourceNode && targetNode) {
+        // Check if this edge already exists
+        const existingEdge = edges.find(
+          (e) =>
+            e.type === rel.type &&
+            e.source === sourceNode.id &&
+            e.target === targetNode.id,
+        );
+
+        if (!existingEdge) {
+          edgeIndex += 1;
+          edges.push({
+            id: `e${edgeIndex}`,
+            type: rel.type as RelationType,
+            source: sourceNode.id,
+            target: targetNode.id,
+            properties: rel.properties ?? {},
+            sourceChunk: chunkId,
+            confidence: rel.confidence,
+          });
+        }
+      }
+    }
+  }
+
+  return {
+    nodes,
+    edges,
+    metadata: {
+      documentCount,
+      chunkCount: extractions.length,
+      extractionModel,
+    },
+  };
+};
+
+export const summarizeGraph = (graph: KnowledgeGraph): string => {
+  if (graph.nodes.length === 0) {
+    return "No entities or relationships were extracted from the documents.";
+  }
+
+  const lines: string[] = [];
+  lines.push("=== Knowledge Graph Summary ===\n");
+
+  // Group nodes by type
+  const nodesByType = new Map<EntityType, GraphNode[]>();
+  for (const node of graph.nodes) {
+    const existing = nodesByType.get(node.type) ?? [];
+    existing.push(node);
+    nodesByType.set(node.type, existing);
+  }
+
+  // Summary stats
+  lines.push(`Entities: ${graph.nodes.length}`);
+  lines.push(`Relationships: ${graph.edges.length}`);
+  lines.push("");
+
+  // List entities by type
+  lines.push("--- Entities by Type ---");
+  for (const [type, nodes] of nodesByType) {
+    const names = nodes.map((n) => n.name).join(", ");
+    lines.push(`${type}: ${names}`);
+  }
+  lines.push("");
+
+  // List key relationships
+  if (graph.edges.length > 0) {
+    lines.push("--- Key Relationships ---");
+    const nodeById = new Map(graph.nodes.map((n) => [n.id, n]));
+
+    for (const edge of graph.edges.slice(0, 20)) {
+      // Limit to 20 relationships for summary
+      const source = nodeById.get(edge.source);
+      const target = nodeById.get(edge.target);
+      if (source && target) {
+        lines.push(`- ${source.name} --[${edge.type}]--> ${target.name}`);
+      }
+    }
+
+    if (graph.edges.length > 20) {
+      lines.push(`... and ${graph.edges.length - 20} more relationships`);
+    }
+  }
+
+  return lines.join("\n");
+};
+
+export const serializeGraph = (graph: KnowledgeGraph): string => {
+  return JSON.stringify(graph, null, 2);
+};

--- a/src/lib/prompts.ts
+++ b/src/lib/prompts.ts
@@ -29,3 +29,86 @@ Preserve meaning, keep citations exactly as provided, and do not add new facts.
 If the draft is insufficient, explicitly say what is missing.
 Structure the response with clear headings and short paragraphs.
 `.trim();
+
+export const ENTITY_EXTRACTION_PROMPT = `
+You are an entity and relationship extraction model analyzing a document snippet.
+Extract named entities and relationships from the text.
+
+Entity Types:
+- party: Companies, individuals, signatories
+- date: Effective dates, deadlines, terms
+- amount: Dollar amounts, percentages, quantities
+- clause: Named clauses (indemnification, termination, etc.)
+- obligation: Duties, requirements, commitments
+- right: Permissions, entitlements
+- condition: Prerequisites, triggers
+- document: Source document references
+- section: Document sections/articles
+
+Relationship Types:
+- has_obligation: Party → Obligation
+- has_right: Party → Right
+- references: Clause → Clause (cross-references)
+- depends_on: Obligation → Condition
+- effective_on: Clause → Date
+- expires_on: Clause → Date
+- involves_amount: Obligation → Amount
+- defined_in: Entity → Document/Section
+- related_to: Generic relationship
+
+Return JSON with this schema:
+{
+  "entities": [
+    { "type": "<entity_type>", "name": "<entity_name>", "properties": {}, "confidence": 0.0-1.0 }
+  ],
+  "relationships": [
+    { "type": "<relation_type>", "sourceName": "<entity_name>", "targetName": "<entity_name>", "properties": {}, "confidence": 0.0-1.0 }
+  ]
+}
+
+Only extract entities and relationships explicitly present in the text.
+Do not infer or speculate. Return JSON only.
+`.trim();
+
+export const GRAPH_SUB_PROMPT = `
+You are a sub model analyzing a single snippet from a larger document.
+You must perform two tasks:
+
+1. FINDINGS: Analyze the snippet for relevance to the question.
+2. ENTITIES: Extract entities and relationships from the snippet.
+
+Only use the snippet. Do not speculate beyond it.
+
+Return JSON with this schema:
+{
+  "finding": {
+    "relevant": true/false,
+    "summary": "<factual summary if relevant, empty string if not>",
+    "citations": ["<chunk_id>"]
+  },
+  "extraction": {
+    "entities": [
+      { "type": "<party|date|amount|clause|obligation|right|condition|document|section>", "name": "<name>", "properties": {}, "confidence": 0.0-1.0 }
+    ],
+    "relationships": [
+      { "type": "<has_obligation|has_right|references|depends_on|effective_on|expires_on|involves_amount|defined_in|related_to>", "sourceName": "<entity_name>", "targetName": "<entity_name>", "properties": {}, "confidence": 0.0-1.0 }
+    ]
+  }
+}
+
+Return JSON only.
+`.trim();
+
+export const GRAPH_ROOT_PROMPT = `
+You are the root model for a document analysis run with knowledge graph context.
+You receive extracted findings from smaller snippets AND a summary of the knowledge graph.
+
+Use both the findings and the graph context to answer the question.
+The graph shows entities (parties, dates, amounts, clauses, etc.) and their relationships.
+
+Answer the question using only the information provided.
+If the findings are insufficient, say what is missing.
+Include citations using bracketed chunk IDs like [doc-1-chunk-3].
+Reference graph entities when relevant (e.g., "Party A (Acme Corp) has...").
+Keep the response structured and concise.
+`.trim();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type AnalyzeMode = "base" | "retrieval" | "rlm";
+export type AnalyzeMode = "base" | "retrieval" | "rlm" | "rlm-graph";
 
 export type DocumentInput = {
   id: string;
@@ -29,6 +29,8 @@ export type AnalyzeDebug = {
   subcalls?: number;
   truncated?: boolean;
   mode?: AnalyzeMode;
+  graphNodes?: number;
+  graphEdges?: number;
 };
 
 export type AnalyzeResponse = {
@@ -36,6 +38,7 @@ export type AnalyzeResponse = {
   mode: AnalyzeMode;
   usage?: AnalyzeUsage;
   debug?: AnalyzeDebug;
+  graph?: KnowledgeGraph;
 };
 
 export type Chunk = {
@@ -53,4 +56,72 @@ export type SubFinding = {
   citations: string[];
   chunkId: string;
   docId: string;
+};
+
+// Knowledge Graph Types
+export type EntityType =
+  | "party"
+  | "date"
+  | "amount"
+  | "clause"
+  | "obligation"
+  | "right"
+  | "condition"
+  | "document"
+  | "section";
+
+export type RelationType =
+  | "has_obligation"
+  | "has_right"
+  | "references"
+  | "depends_on"
+  | "effective_on"
+  | "expires_on"
+  | "involves_amount"
+  | "defined_in"
+  | "related_to";
+
+export type GraphNode = {
+  id: string;
+  type: EntityType;
+  name: string;
+  properties: Record<string, unknown>;
+  sourceChunks: string[];
+  confidence: number;
+};
+
+export type GraphEdge = {
+  id: string;
+  type: RelationType;
+  source: string;
+  target: string;
+  properties: Record<string, unknown>;
+  sourceChunk: string;
+  confidence: number;
+};
+
+export type KnowledgeGraph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  metadata: {
+    documentCount: number;
+    chunkCount: number;
+    extractionModel: string;
+  };
+};
+
+export type EntityExtraction = {
+  entities: Array<{
+    type: EntityType;
+    name: string;
+    properties?: Record<string, unknown>;
+    confidence: number;
+  }>;
+  relationships: Array<{
+    type: RelationType;
+    sourceName: string;
+    targetName: string;
+    properties?: Record<string, unknown>;
+    confidence: number;
+  }>;
 };


### PR DESCRIPTION
## Summary

- Implements Issue #1: RLM + Knowledge Graph analysis mode
- Adds 4th analysis mode that extracts entities (parties, dates, amounts, clauses, obligations) and relationships from documents
- Builds a knowledge graph during analysis for cross-document reasoning
- Displays extracted graph in collapsible UI panel

## Changes

### New Files
- `src/lib/graph.ts` - Graph building with entity merging and fuzzy matching
- `src/lib/__tests__/graph.test.ts` - 11 unit tests for graph module

### Modified Files
- `src/lib/types.ts` - Knowledge graph types (EntityType, RelationType, GraphNode, GraphEdge, KnowledgeGraph)
- `src/lib/prompts.ts` - GRAPH_SUB_PROMPT, GRAPH_ROOT_PROMPT for entity extraction
- `src/app/api/analyze-stream/route.ts` - rlm-graph mode handler with SSE graph streaming
- `src/app/page.tsx` - 4th mode tab and collapsible graph display
- `CLAUDE.md` - Updated documentation

## Test plan

- [x] All 120 tests pass (`npm run test:run`)
- [x] Build succeeds (`npm run build`)
- [ ] Manual test: Select "RLM + Graph" mode and analyze a contract document
- [ ] Verify entities are extracted and displayed in collapsible graph panel
- [ ] Verify relationships show correct source → type → target format

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)